### PR TITLE
Separate log entry preparation and formatting from logging.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Separate log entry preparation and formatting from logging.
+  This makes it easier to extend the logging by patching those methods.
+  [jone]
 
 
 1.3 (2015-06-12)

--- a/src/collective/usernamelogger/__init__.py
+++ b/src/collective/usernamelogger/__init__.py
@@ -55,10 +55,7 @@ def username(cookie, name=None):
     return name
 
 
-# the following is a copy of the `log` method from
-# `ZServer.medusa.http_server.http_request.py` (around line 272)
-# plus the extra call to the above function to extract the username
-def log (self, bytes):
+def prepare_log_entry(self, bytes):
     user_agent=self.get_header('user-agent')
     if not user_agent: user_agent=''
     referer=self.get_header('referer')
@@ -89,15 +86,33 @@ def log (self, bytes):
     # support for cookies and cookie authentication
     name = username(self.get_header('Cookie'), name)
 
-    self.channel.server.logger.log (
-        ip_addr,
-        '- %s [%s] "%s" %d %d "%s" "%s"\n' % (
-            name,
-            self.log_date_string (time()),
-            self.request,
-            self.reply_code,
-            bytes,
-            referer,
-            user_agent
-            )
-        )
+    return {'ip_addr': ip_addr,
+            'user': name,
+            'date': self.log_date_string (time()),
+            'request_line': self.request,
+            'response_code': self.reply_code,
+            'bytes': bytes,
+            'referer': referer,
+            'user_agent': user_agent}
+
+
+def format_log_entry(self, data):
+    return '- %(user)s [%(date)s] "%(request_line)s" %(response_code)d' \
+        ' %(bytes)d "%(referer)s" "%(user_agent)s"\n' % data
+
+
+# the following is a copy of the `log` method from
+# `ZServer.medusa.http_server.http_request.py` (around line 272)
+# plus the extra call to the above function to extract the username
+def log (self, bytes):
+    data = self.prepare_log_entry(bytes)
+    message = self.format_log_entry(data)
+    self.channel.server.logger.log(data['ip_addr'], message)
+
+
+def apply_patches(scope, original, replacement):
+    # This patches ".log":
+    setattr(scope, original, replacement)
+    # we also need our helper methods:
+    setattr(scope, 'prepare_log_entry', prepare_log_entry)
+    setattr(scope, 'format_log_entry', format_log_entry)

--- a/src/collective/usernamelogger/configure.zcml
+++ b/src/collective/usernamelogger/configure.zcml
@@ -7,6 +7,7 @@
 
   <monkey:patch
      class="ZServer.medusa.http_server.http_request"
+     handler=".apply_patches"
      original="log"
      replacement=".log"
      docstringWarning="false" />


### PR DESCRIPTION
This makes it easier to extend the logging by patching those methods.

The method `prepare_log_entry` prepares a dict with information for the log entry, which is then passed to the `format_log_entry` for formatting a message-string.
The `log` method only calls those two methods and then calls the logger.

By separating those steps we can easily extend logging data by patching `format_log_entry`.
Existing parts of the log message can be changed by patching `prepare_log_entry` and modifiying the result of a super-call to the original method.

_monkeypatcher:_
With `collective.monkeypatcher` it is not possible to add a new method, only existing methods can be patched.
I've therefore added a custom patch handler function, which also adds the two helper functions.

@lukasgraf can you please take a look?
