### PR TITLE
Make session cookie name configurable via environment variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 1.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Make session cookie name configurable via environment variable:
+  Using the env variable USERNAMELOGGER_AC_COOKIE_NAME, the session cookie
+  name can be set to a different value than the default of '__ac'.
+  [lgraf]
 
 
 1.3 (2015-06-12)

--- a/src/collective/usernamelogger/__init__.py
+++ b/src/collective/usernamelogger/__init__.py
@@ -4,6 +4,10 @@ from urllib import unquote
 from Cookie import CookieError, SimpleCookie
 from ZPublisher import HTTPRequest
 
+import os
+
+cookie_name = os.environ.get('USERNAMELOGGER_AC_COOKIE_NAME', '__ac')
+
 
 def repeatedly_unquote(cookie):
     """Keep unquoting the cookie value until it doesn't change any more.
@@ -28,9 +32,9 @@ def username(cookie, name=None):
         except CookieError:
             return name
 
-        if '__ac' in cookies:
+        if cookie_name in cookies:
             # Deal with doubly quoted cookies
-            ac_cookie = repeatedly_unquote(cookies['__ac'].value)
+            ac_cookie = repeatedly_unquote(cookies[cookie_name].value)
 
             try:
                 ac = decodestring(ac_cookie + '=====')


### PR DESCRIPTION
Using the env variable `USERNAMELOGGER_AC_COOKIE_NAME`, the session cookie name can be set to a different value than the default of `__ac`.
This allows for setting the proper cookie name in cases where a non-standard session cookie name is used, and avoids erroneously reading and logging an incorrect username from the wrong session cookie.

Ideally, we would determine the cookie name by looking at the session Plugin's `cookie_name` property - but this would require access to a site, which we simply don't have in the code that performs the logging.

Fixes #3

/cc @buchi